### PR TITLE
update livelinessProbe

### DIFF
--- a/labs/lab3/mariadb/scripts/config_mariadb.sh
+++ b/labs/lab3/mariadb/scripts/config_mariadb.sh
@@ -8,11 +8,11 @@ __mysql_config() {
 #  chown -R mysql:mysql /var/lib/mysql
   /usr/bin/mysqld_safe &
   sleep 10
-}
+)}
 
 __setup_mysql() {
   printf "Running the start_mysql function.\n"
-  ROOT_PASS="$(openssl rand -base64 12)"
+  ROOT_PASS="${DBROOTPASS-$(openssl rand -base64 12)}"
   USER="${DBUSER-dbuser}"
   PASS="${DBPASS-$(openssl rand -base64 12)}"
   NAME="${DBNAME-db}"

--- a/labs/lab5/wordpress-template.yaml
+++ b/labs/lab5/wordpress-template.yaml
@@ -38,13 +38,18 @@ objects:
             value: ${DBPASS}
           - name: DBUSER
             value: ${DBUSER}
+          - name: DBROOTPASS
+            value: ${DBROOTPASS}
           image: 'localhost:5000/mariadb:latest'
           imagePullPolicy: Always
           livenessProbe:
-            initialDelaySeconds: 45
-            tcpSocket:
-              port: 3306
+            exec:
+              command: ["sh", "-c", "exec mysqladmin status -uroot -p$DBROOTPASS"]
+            initialDelaySeconds: 120
+            periodSeconds: 10
             timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           name: mariadb
           ports:
           - containerPort: 3306
@@ -163,6 +168,12 @@ parameters:
   displayName: MariaDB Password
   from: '[a-zA-Z0-9]{12}'
   name: DBPASS
+  required: true
+  generate: expression
+- description: Password for MariaDB root user.
+  displayName: MariaDB Root Password
+  from: '[a-zA-Z0-9]{12}'
+  name: DBROOTPASS
   required: true
   generate: expression
 - description: Name of the MariaDB database accessed.


### PR DESCRIPTION
tcp liveliness probe caused mariadb to block the host making the probe due to all the abandoned sql connections. Updated to use a command. 

based on https://github.com/helm/charts/tree/master/stable/mariadb